### PR TITLE
Set base address in linker script

### DIFF
--- a/rpi_bm/part10/src/linker.ld
+++ b/rpi_bm/part10/src/linker.ld
@@ -1,5 +1,6 @@
 SECTIONS
 {
+    . = 0x80000;
     .text.boot : { *(.text.boot) }
     .text : { *(.text) }
     .rodata : { *(.rodata) }

--- a/rpi_bm/part11/src/linker.ld
+++ b/rpi_bm/part11/src/linker.ld
@@ -1,5 +1,6 @@
 SECTIONS
 {
+    . = 0x80000;
     .text.boot : { *(.text.boot) }
     .text : { *(.text) }
     .rodata : { *(.rodata) }

--- a/rpi_bm/part6-7/src/linker.ld
+++ b/rpi_bm/part6-7/src/linker.ld
@@ -1,5 +1,6 @@
 SECTIONS
 {
+    . = 0x80000;
     .text.boot : { *(.text.boot) }
     .text : { *(.text) }
     .rodata : { *(.rodata) }

--- a/rpi_bm/part8/src/linker.ld
+++ b/rpi_bm/part8/src/linker.ld
@@ -1,5 +1,6 @@
 SECTIONS
 {
+    . = 0x80000;
     .text.boot : { *(.text.boot) }
     .text : { *(.text) }
     .rodata : { *(.rodata) }

--- a/rpi_bm/part9/src/linker.ld
+++ b/rpi_bm/part9/src/linker.ld
@@ -1,5 +1,6 @@
 SECTIONS
 {
+    . = 0x80000;
     .text.boot : { *(.text.boot) }
     .text : { *(.text) }
     .rodata : { *(.rodata) }


### PR DESCRIPTION
- [RPi config documentation](https://www.raspberrypi.org/documentation/configuration/config-txt/boot.md) specifies that by default in 64-bit mode kernel_address=0x80000.
  - Setting kernel_address=0x0 causes the kernel to fail to boot, likely because of the armstub (from 0x0 to 0x100).
- When adding thread/process scheduling, having a mismatch between kernel_address (in config.txt) and the specified base address results in garbage data
- This base address will need to be modified again when adding virtual memory, as the kernel's area of the address space is typically the higher addresses of the overall virtual address space.
- This is verified to work on Raspberry Pi 3B and 4B w/ a basic thread scheduler

Also, I know that this is a bit of a different situation than normal, since the code should be identical or very close to what's on YouTube. If you'd like, I could instead submit a PR w/ a "part12" for implementing a scheduler that has the proper base address, or I can create an issue for other people who may want to go ahead w/ Sergey's tutorial but run into address space problems like I did.

Thank you for posting this repo and your videos. They're a wonderful service to the community.