### PR TITLE
fix malloc mmap implementation's header size

### DIFF
--- a/linux_os/part10/src/mylib/mem.c
+++ b/linux_os/part10/src/mylib/mem.c
@@ -174,7 +174,7 @@ void *malloc(size_t in_size) {
 
     if (in_size >= MMAP_THRESHOLD) {
         //not going to use heap, actually use mmap instead...
-        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE_MASK, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         chunk_set_size(p, in_size);
         chunk_set_flags(p, FLAG_MEM_MAPPED | FLAG_MEM_ALLOCATED);
 

--- a/linux_os/part6/src/mylib/mem.c
+++ b/linux_os/part6/src/mylib/mem.c
@@ -174,7 +174,7 @@ void *malloc(size_t in_size) {
 
     if (in_size >= MMAP_THRESHOLD) {
         //not going to use heap, actually use mmap instead...
-        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE_MASK, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         chunk_set_size(p, in_size);
         chunk_set_flags(p, FLAG_MEM_MAPPED | FLAG_MEM_ALLOCATED);
 

--- a/linux_os/part7/src/mylib/mem.c
+++ b/linux_os/part7/src/mylib/mem.c
@@ -174,7 +174,7 @@ void *malloc(size_t in_size) {
 
     if (in_size >= MMAP_THRESHOLD) {
         //not going to use heap, actually use mmap instead...
-        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE_MASK, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         chunk_set_size(p, in_size);
         chunk_set_flags(p, FLAG_MEM_MAPPED | FLAG_MEM_ALLOCATED);
 

--- a/linux_os/part8/src/mylib/mem.c
+++ b/linux_os/part8/src/mylib/mem.c
@@ -174,7 +174,7 @@ void *malloc(size_t in_size) {
 
     if (in_size >= MMAP_THRESHOLD) {
         //not going to use heap, actually use mmap instead...
-        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE_MASK, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         chunk_set_size(p, in_size);
         chunk_set_flags(p, FLAG_MEM_MAPPED | FLAG_MEM_ALLOCATED);
 

--- a/linux_os/part9/src/mylib/mem.c
+++ b/linux_os/part9/src/mylib/mem.c
@@ -174,7 +174,7 @@ void *malloc(size_t in_size) {
 
     if (in_size >= MMAP_THRESHOLD) {
         //not going to use heap, actually use mmap instead...
-        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE_MASK, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        uint8_t *p = sys_mmap(NULL, in_size + HEADER_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         chunk_set_size(p, in_size);
         chunk_set_flags(p, FLAG_MEM_MAPPED | FLAG_MEM_ALLOCATED);
 


### PR DESCRIPTION
Hey!

I am working on a similar project and am taking some guidance.
I was looking through your malloc implementation and found a logical error.
In the mmap call, you seem to have mixed up HEADER_SIZE_MASK and HEADER_SIZE
This probably hasn't been tested. (as allocations over 128kb are rare)

old header size: 4294967288 bytes
new header size: 4 bytes
diff: -4294967284 bytes (:D)